### PR TITLE
[BUG] Fix reset() method for v2

### DIFF
--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -457,7 +457,13 @@ class SawyerXYZEnv(SawyerMocapBase, metaclass=abc.ABCMeta):
 
     def reset(self):
         self.curr_path_length = 0
-        return super().reset()
+        
+        ## reset self._prev_obs to current observation
+        obs = super().reset()
+        self._prev_obs = obs[:18].copy()
+        obs[18:36] = self._prev_obs
+
+        return obs
 
     def _reset_hand(self, steps=50):
         for _ in range(steps):


### PR DESCRIPTION
`reset()` method does not reset the `self._prev_obs`. It creates inconsistent reset state which is supposed to be deterministic for the same tasks in the same environment (by task, I mean parametric variation).
```Python3
import metaworld

benchmark = metaworld.MT1("reach-v2", 0)
env = benchmark.train_classes["reach-v2"]()
env.set_task(benchmark.train_tasks[0])

reset_1 = env.reset()
reset_2 = env.reset()
_ = env.step(env.action_space.sample())
reset_3 = env.reset()
reset_4 = env.reset()

print(reset_1 == reset_2)
"""
[ True  True  True  True  True  True  True  True  True  True  True  True
  True  True  True  True  True  True  True  True  True  True  True  True
  True  True  True  True  True  True  True  True  True  True  True  True
  True  True  True]
"""

print(reset_1 == reset_3)
"""
[ True  True  True  True  True  True  True  True  True  True  True  True
  True  True  True  True  True  True False False False  True False False
 False False False False False  True  True  True  True  True  True  True
  True  True  True]
"""

print(reset_1 == reset_4)
"""
[ True  True  True  True  True  True  True  True  True  True  True  True
  True  True  True  True  True  True  True  True  True  True  True  True
  True  True  True  True  True  True  True  True  True  True  True  True
  True  True  True]
"""
```

The following changes will return all `True` for `reset_1 == reset_3`.