### PR TITLE
Disable nightly CI (CI on commit still runs)

### DIFF
--- a/.github/workflows/metaworld-ci.yml
+++ b/.github/workflows/metaworld-ci.yml
@@ -8,8 +8,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  schedule:
-    - cron: '0 0 * * *'
 
 env:
   MJKEY: ${{ secrets.MJKEY }}


### PR DESCRIPTION
Nightly CI is largely redundant with running the CI on pull requests, and it uses a lot of compute, so we should disable it.