### PR TITLE
Improvement to setup and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ You may wish to only access individual environments used in the Metaworld benchm
 
 ### Seeding a Benchmark Instance
 For the purposes of reproducibility, it may be important to you to seed your benchmark instance.
-You can do so in the following way:
+For example, for the ML1 benchmark environment with the 'pick-place-v2' environment, you can do so in the following way:
 ```python
 import metaworld
 
 SEED = 0  # some seed number here
-benchmark = metaworld.BENCHMARK(seed=SEED)
+benchmark = metaworld.ML1('pick-place-v2', seed=SEED)
 ```
 
 ### Running ML1 or MT1
@@ -78,9 +78,9 @@ import random
 
 print(metaworld.ML1.ENV_NAMES)  # Check out the available environments
 
-ml1 = metaworld.ML1('pick-place-v1') # Construct the benchmark, sampling tasks
+ml1 = metaworld.ML1('pick-place-v2') # Construct the benchmark, sampling tasks
 
-env = ml1.train_classes['pick-place-v1']()  # Create an environment with task `pick_place`
+env = ml1.train_classes['pick-place-v2']()  # Create an environment with task `pick_place`
 task = random.choice(ml1.train_tasks)
 env.set_task(task)  # Set task
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ required = [
     "gym>=0.15.4",
     "mujoco-py<2.2,>=2.0",
     "numpy>=1.18",
+    "scipy>=1.4.1",
 ]
 
 
@@ -20,7 +21,6 @@ extras["dev"] = [
     "pyquaternion==0.9.5",
     "pytest>=4.4.0",  # Required for pytest-xdist
     "pytest-xdist",
-    "scipy",
 ]
 
 


### PR DESCRIPTION
1. scipy is required to run this package in non-dev mode (even just to import metaworld), so I've updated the setup.py accordingly. Existing users of this package must have just been installing it separately, or always doing a dev install.

2. Updated the examples in the README.
  - The first example with the seed was ambiguous (in my opinion) since "metaworld.BENCHMARK" looked like runnable code rather than a placeholder. Have updated so that the code is runnable
  - The next example would not run due to the absent environment, so is updated (ValueError: pick-place-v1 is not a V2 environment)