### PR TITLE
removed unneccessary import

### DIFF
--- a/metaworld/__init__.py
+++ b/metaworld/__init__.py
@@ -7,8 +7,6 @@ from typing import List, NamedTuple, Type
 import numpy as np
 from memory_profiler import profile
 
-import metaworld.envs.mujoco.env_dict as _env_dict
-
 EnvName = str
 
 


### PR DESCRIPTION
from my testing I left in a "import memory_profiler" line that will cause an error as it's not included in the setup.toml