### PR TITLE
Changing step to return truncate=True 

### DIFF
--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -459,7 +459,7 @@ class SawyerXYZEnv(SawyerMocapBase, EzPickle):
         assert len(action) == 4, f"Actions should be size 4, got {len(action)}"
         self.set_xyz_action(action[:3])
         if self.curr_path_length == self.max_path_length:
-            raise ValueError("You must reset the env manually once truncate==True")          
+            raise ValueError("You must reset the env manually once truncate==True")
         self.do_simulation([action[-1], -action[-1]], n_frames=self.frame_skip)
         self.curr_path_length += 1
 

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -496,10 +496,7 @@ class SawyerXYZEnv(SawyerMocapBase, EzPickle):
         reward, info = self.evaluate_state(self._last_stable_obs, action)
         # step will never return a terminate==True if there is a success
         # but we can return truncate=True if the current path length == max path length
-
-
         truncate = False
-        print(self.curr_path_length)
         if self.curr_path_length == self.max_path_length:
             truncate = True
         return (

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -458,7 +458,7 @@ class SawyerXYZEnv(SawyerMocapBase, EzPickle):
     def step(self, action):
         assert len(action) == 4, f"Actions should be size 4, got {len(action)}"
         self.set_xyz_action(action[:3])
-        if self.curr_path_length == self.max_path_length:
+        if self.curr_path_length >= self.max_path_length:
             raise ValueError("You must reset the env manually once truncate==True")
         self.do_simulation([action[-1], -action[-1]], n_frames=self.frame_skip)
         self.curr_path_length += 1

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -458,11 +458,9 @@ class SawyerXYZEnv(SawyerMocapBase, EzPickle):
     def step(self, action):
         assert len(action) == 4, f"Actions should be size 4, got {len(action)}"
         self.set_xyz_action(action[:3])
+        if self.curr_path_length == self.max_path_length:
+            raise ValueError("You must reset the env manually once truncate==True")          
         self.do_simulation([action[-1], -action[-1]], n_frames=self.frame_skip)
-        if self.curr_path_length > self.max_path_length:
-            raise ValueError(
-                "Maximum path length allowed by the benchmark has been exceeded"
-            )
         self.curr_path_length += 1
 
         # Running the simulator can sometimes mess up site positions, so
@@ -496,12 +494,19 @@ class SawyerXYZEnv(SawyerMocapBase, EzPickle):
             dtype=np.float64,
         )
         reward, info = self.evaluate_state(self._last_stable_obs, action)
-        # step will never return a terminal if there is a success
+        # step will never return a terminate==True if there is a success
+        # but we can return truncate=True if the current path length == max path length
+
+
+        truncate = False
+        print(self.curr_path_length)
+        if self.curr_path_length == self.max_path_length:
+            truncate = True
         return (
             np.array(self._last_stable_obs, dtype=np.float64),
             reward,
             False,
-            False,
+            truncate,
             info,
         )
 


### PR DESCRIPTION
in the previous version of Meta-World, there was a check to see if the current trajectory has equalled the maximum trajectory length. Now with environments returning termination and truncation signals, we can add a check to see if truncate should be sent by comparing the current trajectory length to the maximum trajectory length. To ensure that the environment does get reset, the ValueError that was normally raised hasn't been changed. 