### PR TITLE
Ensure correct seeding behaviour. Using the self.np_random rather tha…

### DIFF
--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -522,8 +522,10 @@ class SawyerXYZEnv(SawyerMocapBase, EzPickle):
         raise NotImplementedError
 
     def reset(self, seed=None, options=None):
+        if seed:
+            self.seed(seed)
         self.curr_path_length = 0
-        obs, info = super().reset()
+        obs, info = super().reset(seed=seed)
         self._prev_obs = obs[:18].copy()
         obs[18:36] = self._prev_obs
         obs = np.float64(obs)
@@ -544,7 +546,7 @@ class SawyerXYZEnv(SawyerMocapBase, EzPickle):
             assert self._last_rand_vec is not None
             return self._last_rand_vec
         else:
-            rand_vec = np.random.uniform(
+            rand_vec = self.np_random.uniform(
                 self._random_reset_space.low,
                 self._random_reset_space.high,
                 size=self._random_reset_space.low.size,


### PR DESCRIPTION
This is a PR to solve issue #461  
Ensure correct seeding behaviour. Using the self.np_random rather than the np.random. This makes sure:

1. Deterministic env resetting.
2. Different seeds for envs running in parallel, e.g. Async Vector Env of gymnasium.
3. Make the seed in the reset function useful, following the gymnasium interface.