### PR TITLE
remove geom name attribute in block.xml

### DIFF
--- a/metaworld/envs/assets_v2/objects/assets/block.xml
+++ b/metaworld/envs/assets_v2/objects/assets/block.xml
@@ -1,6 +1,6 @@
 <mujocoinclude>
     <body childclass="block_base">
       <geom material="block_wood" pos="0 0 .02" mesh="block"/>
-      <geom name="objGeom" class="block_col" pos="0 0 .02" size="0.02 0.02 0.02" type="box" mass=".1"/>
+      <geom class="block_col" pos="0 0 .02" size="0.02 0.02 0.02" type="box" mass=".1"/>
     </body>
 </mujocoinclude>


### PR DESCRIPTION
It seems that the `name` attribute of `geom` in the `block.xml` will raise the following issue when I include `block.xml` in a new environment.

```
    model = mujoco.MjModel.from_xml_path(self.fullpath)
ValueError: Error: repeated name in geom array, position 53
```

Removing the geom name will fix the problem.