### PR TITLE
Fixing qpos order in the xml of the basketball task.

### DIFF
--- a/metaworld/envs/assets_v2/sawyer_xyz/sawyer_basketball.xml
+++ b/metaworld/envs/assets_v2/sawyer_xyz/sawyer_basketball.xml
@@ -5,11 +5,15 @@
 
   <worldbody>
 
+      <!-- <body name="bsktball" pos="0 0.6 0.03">
+        <freejoint/>
+        <include file="../objects/assets/basketball.xml"/>
+      </body> -->
+      <include file="../objects/assets/xyz_base.xml"/>
       <body name="bsktball" pos="0 0.6 0.03">
         <freejoint/>
         <include file="../objects/assets/basketball.xml"/>
       </body>
-      <include file="../objects/assets/xyz_base.xml"/>
 
       <body name="basket_goal" pos="0. 0.9 0">
          <include file="../objects/assets/basketballhoop.xml"/>


### PR DESCRIPTION
I found that the order to initialize mujoco bodies in the xml of the basketball v2 task is slightly different with others. This results in unexpected initial robot poses. An example is shown below:

![before](https://github.com/Farama-Foundation/Metaworld/assets/58632091/0c1ef227-a082-44fc-9c71-89b10dc0f8f3)

In this function, the object is assumed to follow the robot qpos, however, in the xml for the basketball file, the order is inconsistent, which leads to unexpected initial pose of the robot.

https://github.com/Farama-Foundation/Metaworld/blob/87ac948c6f48475a962f9493cfdb8c338925cc74/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py#L248-L254

In this pull request, I put the basketball behind the robot in the xml, and this issue seems to be resolved.

![after](https://github.com/Farama-Foundation/Metaworld/assets/58632091/8f39b22e-47b6-44d4-98eb-d0d1d1cddbd9)
