### PR TITLE
Update MuJoCo to 3.X

### DIFF
--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -131,7 +131,7 @@ class SawyerMocapBase(mjenv_gym):
             for i in range(self.model.eq_data.shape[0]):
                 if self.model.eq_type[i] == mujoco.mjtEq.mjEQ_WELD:
                     self.model.eq_data[i] = np.array(
-                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 3.75]
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 4]
                     )
 
 

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -131,7 +131,7 @@ class SawyerMocapBase(mjenv_gym):
             for i in range(self.model.eq_data.shape[0]):
                 if self.model.eq_type[i] == mujoco.mjtEq.mjEQ_WELD:
                     self.model.eq_data[i] = np.array(
-                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 3.75]
                     )
 
 

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -131,7 +131,7 @@ class SawyerMocapBase(mjenv_gym):
             for i in range(self.model.eq_data.shape[0]):
                 if self.model.eq_type[i] == mujoco.mjtEq.mjEQ_WELD:
                     self.model.eq_data[i] = np.array(
-                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 4]
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 5]
                     )
 
 

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -131,7 +131,7 @@ class SawyerMocapBase(mjenv_gym):
             for i in range(self.model.eq_data.shape[0]):
                 if self.model.eq_type[i] == mujoco.mjtEq.mjEQ_WELD:
                     self.model.eq_data[i] = np.array(
-                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 5]
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 8.2]
                     )
 
 

--- a/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
+++ b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py
@@ -131,7 +131,7 @@ class SawyerMocapBase(mjenv_gym):
             for i in range(self.model.eq_data.shape[0]):
                 if self.model.eq_type[i] == mujoco.mjtEq.mjEQ_WELD:
                     self.model.eq_data[i] = np.array(
-                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 8.2]
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 5.0]
                     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "gymnasium>=1.0.0a1",
-    "mujoco<3.0.0",
+    "mujoco>=3.0.0",
     "numpy>=1.18",
     "scipy>=1.4.1",
     "imageio"


### PR DESCRIPTION
A key part missing from recent Metaworld renovation work is to stop depending on MuJoCo 2.X. Upgrading to MuJoCo 3.X opens up useful features such as:
- The ability to use MJX in the future
- The repository properly installing and working on latest macOS (MuJoCo 2's library path for OpenGL is wrong)

The main reason for not using MuJoCo 3.X before was that the benchmark did not work as intended and appeared to be broken (i.e. tests would fail).

Over the past few months, I did a deep dive on why this is and how to fix it. You can find a relatively in-depth documentation of the process and the findings in [this issue on the MuJoCo repo](https://github.com/google-deepmind/mujoco/issues/1483).

In the end I had to make a single change to get it working:
- Adjust the mocap weld constraint to have the correct relative position we want between the hand and the mocap bodies (that's what changing `1.0` to `-1.0` achieves, which corresponds to the first part of the quaternion in the rotational part of the relpose attribute of the weld constraint), and also to weigh the rotational part of the constraint quite high (set torquescale, the last part of the constraint data, to 3.75 from 1.0)

(For an explanation as to why this change was necessary please see the discussion on the [this issue in the MuJoCo repo](https://github.com/google-deepmind/mujoco/issues/1483))

I tried different values for torquecale but found that at 3.5 soccer breaks, and at 3.75 and up everything works.