### PR TITLE
Fix gripperFOV rendering

### DIFF
--- a/metaworld/envs/assets_v2/objects/assets/xyz_base.xml
+++ b/metaworld/envs/assets_v2/objects/assets/xyz_base.xml
@@ -149,7 +149,7 @@
                                               </body> -->
                                               <body name="hand" pos="0 0 0.12" quat="-1 0 1 0">
                                                   <camera name="behindGripper" mode="track" pos="0 0 -0.5" quat="0 1 0 0" fovy="60" />
-                                                  <camera name="gripperPOV" mode="track" pos="0 -0.1 0" quat="-1 -1.3 0 0" fovy="90" />
+                                                  <camera name="gripperPOV" mode="track" pos="0.04 -0.06 0" quat="-1 -1.3 0 0" fovy="90" />
 
                                                   <site name="endEffector" pos="0.04 0 0" size="0.01" rgba='1 1 1 0' />
                                                   <geom name="rail" type="box" pos="-0.05 0 0" density="7850" size="0.005 0.055 0.005"  rgba="0.5 0.5 0.5 1.0" condim="3" friction="2 0.1 0.002"   />


### PR DESCRIPTION
Fix the wrong rendering on the gripper FOV to a correct one.

Old position :
![Screenshot from 2025-03-06 15-41-48](https://github.com/user-attachments/assets/51bc7ab8-ea8e-4d6a-a15b-c8e9937054de)

New position :
![Screenshot from 2025-03-06 15-41-03](https://github.com/user-attachments/assets/9081bcac-6708-4fd8-a92f-6ef4f0d7580f)