### PR TITLE
Fixes typo in docs

### DIFF
--- a/docs/introduction/basic_usage.md
+++ b/docs/introduction/basic_usage.md
@@ -24,7 +24,7 @@ import gymnasium as gym
 import metaworld
 
 SEED = 0  # some seed number here
-env = gym.make('Meta-World/MT1' env_name='reach-v3', seed=seed)
+env = gym.make('Meta-World/MT1', env_name='reach-v3', seed=seed)
 obs, info = env.reset()
 
 a = env.action_space.sample() # randomly sample an action


### PR DESCRIPTION
The example code snippet in the basic_usage.md file had a small typo and was missing a comma. Now, the snippet is free of syntax errors.