### PR TITLE
Update evaluation to support MT1 and fix metalearning evaluation issue

### DIFF
--- a/metaworld/__init__.py
+++ b/metaworld/__init__.py
@@ -116,6 +116,7 @@ def _make_tasks(
     args_kwargs: _env_dict.EnvArgsKwargsDict,
     kwargs_override: dict,
     seed: int | None = None,
+    num_goals: int = _N_GOALS,
 ) -> list[Task]:
     """Initialises goals for a given set of environments.
 
@@ -124,9 +125,10 @@ def _make_tasks(
         args_kwargs: The environment arguments and keyword arguments.
         kwargs_override: Any kwarg overrides.
         seed: The random seed to use.
+        num_goals: The number of goals to generate for each environment.
 
     Returns:
-        A flat list of `Task` objects, `_N_GOALS` for each environment in `classes`.
+        A flat list of `num_goals` different `Task` objects, for each environment in `classes`.
     """
     # Cache existing random state
     if seed is not None:
@@ -149,14 +151,14 @@ def _make_tasks(
         del kwargs["task_id"]
         env._set_task_inner(**kwargs)
 
-        for _ in range(_N_GOALS):  # Generate random goals
+        for _ in range(num_goals):  # Generate random goals
             env.reset()
             assert env._last_rand_vec is not None
             rand_vecs.append(env._last_rand_vec)
         unique_task_rand_vecs = np.unique(np.array(rand_vecs), axis=0)
-        assert (
-            unique_task_rand_vecs.shape[0] == _N_GOALS
-        ), f"Only generated {unique_task_rand_vecs.shape[0]} unique goals, not {_N_GOALS}"
+        assert unique_task_rand_vecs.shape[0] == num_goals, (
+            f"Only generated {unique_task_rand_vecs.shape[0]} unique goals, not {num_goals}"
+        )
         env.close()
 
         # Create a task for each random goal
@@ -190,7 +192,9 @@ class MT1(Benchmark):
 
     ENV_NAMES = list(_env_dict.ALL_V3_ENVIRONMENTS.keys())
 
-    def __init__(self, env_name, seed=None):
+    def __init__(
+        self, env_name: str, seed: int | None = None, num_goals: int = _N_GOALS
+    ):
         super().__init__()
         if env_name not in _env_dict.ALL_V3_ENVIRONMENTS:
             raise ValueError(f"{env_name} is not a V3 environment")
@@ -200,7 +204,11 @@ class MT1(Benchmark):
         args_kwargs = _env_dict.ML1_args_kwargs[env_name]
 
         self._train_tasks = _make_tasks(
-            self._train_classes, {env_name: args_kwargs}, _MT_OVERRIDE, seed=seed
+            self._train_classes,
+            {env_name: args_kwargs},
+            _MT_OVERRIDE,
+            seed=seed,
+            num_goals=num_goals,
         )
 
         self._test_tasks = []
@@ -213,17 +221,18 @@ class MT10(Benchmark):
     Has an empty test set.
     """
 
-    def __init__(self, seed=None):
+    def __init__(self, seed: int | None = None, num_goals: int = _N_GOALS):
         super().__init__()
         self._train_classes = _env_dict.MT10_V3
         self._test_classes = OrderedDict()
-        train_kwargs = _env_dict.MT10_V3_ARGS_KWARGS
         self._train_tasks = _make_tasks(
-            self._train_classes, train_kwargs, _MT_OVERRIDE, seed=seed
+            self._train_classes,
+            _env_dict.MT10_V3_ARGS_KWARGS,
+            _MT_OVERRIDE,
+            seed=seed,
+            num_goals=num_goals,
         )
-
         self._test_tasks = []
-        self._test_classes = []
 
 
 class MT25(Benchmark):
@@ -233,16 +242,17 @@ class MT25(Benchmark):
     Has an empty test set.
     """
 
-    def __init__(self, seed=None):
+    def __init__(self, seed=None, num_goals: int = _N_GOALS):
         super().__init__()
         self._train_classes = _env_dict.MT25_V3
-        train_kwargs = _env_dict.MT25_V3_ARGS_KWARGS
         self._train_tasks = _make_tasks(
-            self._train_classes, train_kwargs, _MT_OVERRIDE, seed=seed
+            self._train_classes,
+            _env_dict.MT25_V3_ARGS_KWARGS,
+            _MT_OVERRIDE,
+            seed=seed,
+            num_goals=num_goals,
         )
-
         self._test_tasks = []
-        self._test_classes = []
 
 
 class MT50(Benchmark):
@@ -252,17 +262,18 @@ class MT50(Benchmark):
     Has an empty test set.
     """
 
-    def __init__(self, seed=None):
+    def __init__(self, seed=None, num_goals: int = _N_GOALS):
         super().__init__()
         self._train_classes = _env_dict.MT50_V3
         self._test_classes = OrderedDict()
-        train_kwargs = _env_dict.MT50_V3_ARGS_KWARGS
         self._train_tasks = _make_tasks(
-            self._train_classes, train_kwargs, _MT_OVERRIDE, seed=seed
+            self._train_classes,
+            _env_dict.MT50_V3_ARGS_KWARGS,
+            _MT_OVERRIDE,
+            seed=seed,
+            num_goals=num_goals,
         )
-
         self._test_tasks = []
-        self._test_classes = []
 
 
 # ML Benchmarks
@@ -463,11 +474,12 @@ def make_mt_envs(
     num_tasks: int | None = None,
     vector_strategy: Literal["sync", "async"] = "sync",
     autoreset_mode: gym.vector.AutoresetMode | str = gym.vector.AutoresetMode.SAME_STEP,
+    num_goals: int = _N_GOALS,
     **kwargs,
 ) -> gym.Env | gym.vector.VectorEnv:
     benchmark: Benchmark
     if name in ALL_V3_ENVIRONMENTS.keys():
-        benchmark = MT1(name, seed=seed)
+        benchmark = MT1(name, seed=seed, num_goals=num_goals)
         tasks = [task for task in benchmark.train_tasks]
         return _init_each_env(  # type: ignore[misc]
             env_cls=benchmark.train_classes[name],
@@ -477,7 +489,7 @@ def make_mt_envs(
             **kwargs,
         )
     elif name == "MT10" or name == "MT25" or name == "MT50":
-        benchmark = globals()[name](seed=seed)
+        benchmark = globals()[name](seed=seed, num_goals=num_goals)
         vectorizer: type[gym.vector.VectorEnv] = getattr(
             gym.vector, f"{vector_strategy.capitalize()}VectorEnv"
         )
@@ -513,6 +525,52 @@ def make_mt_envs(
         )
 
 
+def make_mt1_envs_vectorized(
+    name: str,
+    seed: int | None = None,
+    num_envs: int = 1,
+    vector_strategy: Literal["sync", "async"] = "sync",
+    autoreset_mode: gym.vector.AutoresetMode | str = gym.vector.AutoresetMode.SAME_STEP,
+    num_goals: int = _N_GOALS,
+    **kwargs,
+) -> gym.vector.VectorEnv:
+    if name not in ALL_V3_ENVIRONMENTS.keys():
+        raise ValueError(
+            "Invalid MT1 env name. Must be a valid Metaworld task name (e.g. 'reach-v3')."
+        )
+    if num_goals % num_envs != 0:
+        raise ValueError(
+            f"num_envs must evenly divide num_goals, got num_envs={num_envs} and num_goals={num_goals}."
+        )
+
+    benchmark = MT1(name, seed=seed, num_goals=num_goals)
+    tasks = [task for task in benchmark.train_tasks]
+    tasks_per_env = [tasks[env_idx::num_envs] for env_idx in range(num_envs)]
+    for tasks_for_subenv in tasks_per_env:
+        assert len(tasks_for_subenv) == num_goals // num_envs, (
+            f"Invalid division of subtasks, expected {num_goals // num_envs} got {len(tasks_for_subenv)}"
+        )
+
+    vectorizer: type[gym.vector.SyncVectorEnv | gym.vector.AsyncVectorEnv] = getattr(
+        gym.vector, f"{vector_strategy.capitalize()}VectorEnv"
+    )
+    return vectorizer(
+        [
+            partial(
+                _init_each_env,
+                env_cls=benchmark.train_classes[name],
+                tasks=tasks_for_subenv,
+                seed=seed,
+                env_id=env_idx,
+                num_tasks=num_envs,
+                **kwargs,
+            )
+            for env_idx, tasks_for_subenv in enumerate(tasks_per_env)
+        ],
+        autoreset_mode=autoreset_mode,
+    )
+
+
 def _make_ml_envs_inner(
     benchmark: Benchmark,
     meta_batch_size: int,
@@ -527,9 +585,9 @@ def _make_ml_envs_inner(
         benchmark.train_classes if split == "train" else benchmark.test_classes
     )
     all_tasks = benchmark.train_tasks if split == "train" else benchmark.test_tasks
-    assert (
-        meta_batch_size % len(all_classes) == 0
-    ), "meta_batch_size must be divisible by envs_per_task"
+    assert meta_batch_size % len(all_classes) == 0, (
+        "meta_batch_size must be divisible by envs_per_task"
+    )
     tasks_per_env = meta_batch_size // len(all_classes)
 
     env_tuples = []
@@ -539,9 +597,9 @@ def _make_ml_envs_inner(
             tasks = tasks[:total_tasks_per_cls]
         subenv_tasks = [tasks[i::tasks_per_env] for i in range(0, tasks_per_env)]
         for tasks_for_subenv in subenv_tasks:
-            assert (
-                len(tasks_for_subenv) == len(tasks) // tasks_per_env
-            ), f"Invalid division of subtasks, expected {len(tasks) // tasks_per_env} got {len(tasks_for_subenv)}"
+            assert len(tasks_for_subenv) == len(tasks) // tasks_per_env, (
+                f"Invalid division of subtasks, expected {len(tasks) // tasks_per_env} got {len(tasks_for_subenv)}"
+            )
             env_tuples.append((env_cls, tasks_for_subenv))
 
     vectorizer: type[gym.vector.SyncVectorEnv | gym.vector.AsyncVectorEnv] = getattr(
@@ -610,20 +668,39 @@ def register_mw_envs() -> None:
         vector_strategy: Literal["sync", "async"],
         autoreset_mode: gym.vector.AutoresetMode
         | str = gym.vector.AutoresetMode.SAME_STEP,
-        seed=None,
-        use_one_hot=False,
+        seed: int | None = None,
+        use_one_hot: bool = False,
         num_envs=None,
+        num_goals: int = _N_GOALS,
         **lamb_kwargs,
     ):
-        if "num_goals" in lamb_kwargs:
-            global _N_GOALS
-            _N_GOALS = lamb_kwargs["num_goals"]
-            del lamb_kwargs["num_goals"]
         return make_mt_envs(  # type: ignore
             mt_bench,
             seed=seed,
             use_one_hot=use_one_hot,
+            num_goals=num_goals,
             vector_strategy=vector_strategy,  # type: ignore
+            autoreset_mode=autoreset_mode,
+            **lamb_kwargs,
+        )
+
+    def _mt1_bench_vector_entry_point(
+        mt1_env_name: str,
+        vector_strategy: Literal["sync", "async"],
+        autoreset_mode: gym.vector.AutoresetMode
+        | str = gym.vector.AutoresetMode.SAME_STEP,
+        seed=None,
+        num_envs: int = 1,
+        num_goals: int = _N_GOALS,
+        **lamb_kwargs,
+    ):
+        return make_mt1_envs_vectorized(
+            mt1_env_name,
+            seed=seed,
+            num_envs=num_envs,
+            num_goals=num_goals,
+            use_one_hot=False,
+            vector_strategy=vector_strategy,
             autoreset_mode=autoreset_mode,
             **lamb_kwargs,
         )
@@ -654,14 +731,33 @@ def register_mw_envs() -> None:
 
     register(
         id="Meta-World/MT1",
-        entry_point=lambda env_name, use_one_hot=False, vector_strategy="sync", autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, seed=None, num_envs=None, **kwargs: _mt_bench_vector_entry_point(
-            env_name,
-            vector_strategy,
-            autoreset_mode,
-            seed,
-            use_one_hot,
-            num_envs,
-            **kwargs,
+        entry_point=lambda env_name, use_one_hot=False, vector_strategy="sync", autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, seed=None, num_envs=None, num_goals=_N_GOALS, **kwargs: (
+            _mt_bench_vector_entry_point(
+                env_name,
+                vector_strategy,
+                autoreset_mode,
+                seed,
+                False,
+                num_envs,
+                num_goals,
+                **kwargs,
+            )
+        ),
+        kwargs={},
+    )
+
+    register(
+        id="Meta-World/MT1-vectorized",
+        vector_entry_point=lambda env_name, vector_strategy="sync", autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, seed=None, num_envs=1, num_goals=_N_GOALS, **kwargs: (
+            _mt1_bench_vector_entry_point(
+                env_name,
+                vector_strategy,
+                autoreset_mode,
+                seed,
+                num_envs,
+                num_goals,
+                **kwargs,
+            )
         ),
         kwargs={},
     )
@@ -669,16 +765,18 @@ def register_mw_envs() -> None:
     for split in ["train", "test"]:
         register(
             id=f"Meta-World/ML1-{split}",
-            vector_entry_point=lambda env_name, vector_strategy="sync", autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, total_tasks_per_cls=None, meta_batch_size=20, seed=None, num_envs=None, **kwargs: _ml_bench_vector_entry_point(
-                env_name,
-                split,  # type: ignore[arg-type]
-                vector_strategy,
-                autoreset_mode,
-                total_tasks_per_cls,
-                seed,
-                meta_batch_size,
-                num_envs,
-                **kwargs,
+            vector_entry_point=lambda env_name, vector_strategy="sync", autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, total_tasks_per_cls=None, meta_batch_size=20, seed=None, num_envs=None, **kwargs: (
+                _ml_bench_vector_entry_point(
+                    env_name,
+                    split,  # type: ignore[arg-type]
+                    vector_strategy,
+                    autoreset_mode,
+                    total_tasks_per_cls,
+                    seed,
+                    meta_batch_size,
+                    num_envs,
+                    **kwargs,
+                )
             ),
             kwargs={},
         )
@@ -708,14 +806,17 @@ def register_mw_envs() -> None:
     for mt_bench in ["MT10", "MT25", "MT50"]:
         register(
             id=f"Meta-World/{mt_bench}",
-            vector_entry_point=lambda _mt_bench=mt_bench, vector_strategy="sync", autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, seed=None, use_one_hot=False, num_envs=None, **kwargs: _mt_bench_vector_entry_point(
-                _mt_bench,  # positional arguments
-                vector_strategy,
-                autoreset_mode,
-                seed,
-                use_one_hot,
-                num_envs,
-                **kwargs,
+            vector_entry_point=lambda _mt_bench=mt_bench, vector_strategy="sync", autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, seed=None, use_one_hot=False, num_envs=None, num_goals=_N_GOALS, **kwargs: (
+                _mt_bench_vector_entry_point(
+                    _mt_bench,  # positional arguments
+                    vector_strategy,
+                    autoreset_mode,
+                    seed,
+                    use_one_hot,
+                    num_envs,
+                    num_goals,
+                    **kwargs,
+                )
             ),
             kwargs={},
         )
@@ -724,16 +825,18 @@ def register_mw_envs() -> None:
         for split in ["train", "test"]:
             register(
                 id=f"Meta-World/{ml_bench}-{split}",
-                vector_entry_point=lambda _ml_bench=ml_bench, _split=split, vector_strategy="sync", autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, total_tasks_per_cls=None, seed=None, meta_batch_size=20, num_envs=None, **kwargs: _ml_bench_vector_entry_point(
-                    _ml_bench,
-                    _split,
-                    vector_strategy,
-                    autoreset_mode,
-                    total_tasks_per_cls,
-                    seed,
-                    meta_batch_size,
-                    num_envs,
-                    **kwargs,
+                vector_entry_point=lambda _ml_bench=ml_bench, _split=split, vector_strategy="sync", autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, total_tasks_per_cls=None, seed=None, meta_batch_size=20, num_envs=None, **kwargs: (
+                    _ml_bench_vector_entry_point(
+                        _ml_bench,
+                        _split,
+                        vector_strategy,
+                        autoreset_mode,
+                        total_tasks_per_cls,
+                        seed,
+                        meta_batch_size,
+                        num_envs,
+                        **kwargs,
+                    )
                 ),
                 kwargs={},
             )
@@ -769,14 +872,16 @@ def register_mw_envs() -> None:
 
     register(
         id="Meta-World/custom-mt-envs",
-        vector_entry_point=lambda vector_strategy, envs_list, autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, seed=None, use_one_hot=False, num_envs=None, **kwargs: _custom_mt_vector_entry_point(
-            vector_strategy,
-            envs_list,
-            seed,
-            autoreset_mode,
-            use_one_hot,
-            num_envs,
-            **kwargs,
+        vector_entry_point=lambda vector_strategy, envs_list, autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, seed=None, use_one_hot=False, num_envs=None, **kwargs: (
+            _custom_mt_vector_entry_point(
+                vector_strategy,
+                envs_list,
+                seed,
+                autoreset_mode,
+                use_one_hot,
+                num_envs,
+                **kwargs,
+            )
         ),
         kwargs={},
     )
@@ -805,16 +910,18 @@ def register_mw_envs() -> None:
 
     register(
         id="Meta-World/custom-ml-envs",
-        vector_entry_point=lambda vector_strategy, train_envs, test_envs, autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, total_tasks_per_cls=None, meta_batch_size=20, seed=None, num_envs=None, **kwargs: _custom_ml_vector_entry_point(
-            vector_strategy,
-            train_envs,
-            test_envs,
-            autoreset_mode,
-            total_tasks_per_cls,
-            meta_batch_size,
-            seed,
-            num_envs,
-            **kwargs,
+        vector_entry_point=lambda vector_strategy, train_envs, test_envs, autoreset_mode=gym.vector.AutoresetMode.SAME_STEP, total_tasks_per_cls=None, meta_batch_size=20, seed=None, num_envs=None, **kwargs: (
+            _custom_ml_vector_entry_point(
+                vector_strategy,
+                train_envs,
+                test_envs,
+                autoreset_mode,
+                total_tasks_per_cls,
+                meta_batch_size,
+                seed,
+                num_envs,
+                **kwargs,
+            )
         ),
         kwargs={},
     )

--- a/metaworld/evaluation.py
+++ b/metaworld/evaluation.py
@@ -43,9 +43,15 @@ def _get_task_names(
 
 def evaluation(
     agent: Agent,
-    eval_envs: gym.vector.VectorEnv,
+    eval_envs: gym.Env | gym.vector.VectorEnv,
     num_episodes: int = 50,
 ) -> tuple[float, float, dict[str, float], dict[str, list[float]]]:
+    if not isinstance(eval_envs, gym.vector.VectorEnv):
+        eval_env = eval_envs
+        eval_envs = gym.vector.SyncVectorEnv(
+            [lambda: eval_env], autoreset_mode=gym.vector.AutoresetMode.SAME_STEP
+        )
+
     assert isinstance(eval_envs, QueryableVectorEnv)
 
     terminate_on_success = np.all(eval_envs.get_attr("terminate_on_success")).item()
@@ -72,8 +78,9 @@ def evaluation(
 
         for i, env_ended in enumerate(dones):
             if env_ended:
-                episode_return = float(infos["final_info"]["episode"]["r"][i])
-                success = int(infos["final_info"]["success"][i])
+                final_info = infos.get("final_info", infos)
+                episode_return = float(final_info["episode"]["r"][i])
+                success = int(final_info["success"][i])
 
                 env_episodic_returns[i].append(episode_return)
 

--- a/metaworld/evaluation.py
+++ b/metaworld/evaluation.py
@@ -7,37 +7,33 @@ import numpy as np
 import numpy.typing as npt
 
 from metaworld.env_dict import ALL_V3_ENVIRONMENTS
+from metaworld.types import QueryableVectorEnv
 
 
 class Agent(Protocol):
     def eval_action(
         self, observations: npt.NDArray[np.float64]
-    ) -> npt.NDArray[np.float64]:
-        ...
+    ) -> npt.NDArray[np.float64]: ...
 
-    def reset(self, env_mask: npt.NDArray[np.bool_]) -> None:
-        ...
+    def reset(self, env_mask: npt.NDArray[np.bool_]) -> None: ...
 
 
 class MetaLearningAgent(Agent, Protocol):
-    def init(self) -> None:
-        ...
+    def init(self) -> None: ...
 
     def adapt_action(
         self, observations: npt.NDArray[np.float64]
-    ) -> tuple[npt.NDArray[np.float64], dict[str, npt.NDArray]]:
-        ...
+    ) -> tuple[npt.NDArray[np.float64], dict[str, npt.NDArray]]: ...
 
-    def step(self, timestep: Timestep) -> None:
-        ...
+    def step(self, timestep: Timestep) -> None: ...
 
-    def adapt(self) -> None:
-        ...
+    def adapt(self) -> None: ...
 
 
 def _get_task_names(
-    envs: gym.vector.SyncVectorEnv | gym.vector.AsyncVectorEnv,
+    envs: gym.vector.VectorEnv,
 ) -> list[str]:
+    assert isinstance(envs, QueryableVectorEnv)
     metaworld_cls_to_task_name = {v.__name__: k for k, v in ALL_V3_ENVIRONMENTS.items()}
     return [
         metaworld_cls_to_task_name[task_name]
@@ -47,9 +43,11 @@ def _get_task_names(
 
 def evaluation(
     agent: Agent,
-    eval_envs: gym.vector.SyncVectorEnv | gym.vector.AsyncVectorEnv,
+    eval_envs: gym.vector.VectorEnv,
     num_episodes: int = 50,
 ) -> tuple[float, float, dict[str, float], dict[str, list[float]]]:
+    assert isinstance(eval_envs, QueryableVectorEnv)
+
     terminate_on_success = np.all(eval_envs.get_attr("terminate_on_success")).item()
     eval_envs.call("toggle_terminate_on_success", True)
 
@@ -57,16 +55,15 @@ def evaluation(
     obs, _ = eval_envs.reset()
     agent.reset(np.ones(eval_envs.num_envs, dtype=np.bool_))
 
-    task_names = _get_task_names(eval_envs)
-    successes = {task_name: 0 for task_name in set(task_names)}
-    episodic_returns: dict[str, list[float]] = {
-        task_name: [] for task_name in set(task_names)
+    env_successes = np.zeros(eval_envs.num_envs)
+    env_episodic_returns: dict[int, list[float]] = {
+        i: [] for i in range(eval_envs.num_envs)
     }
 
     def eval_done(returns):
         return all(len(r) >= num_episodes for _, r in returns.items())
 
-    while not eval_done(episodic_returns):
+    while not eval_done(env_episodic_returns):
         actions = agent.eval_action(obs)
         obs, _, terminations, truncations, infos = eval_envs.step(actions)
 
@@ -75,49 +72,71 @@ def evaluation(
 
         for i, env_ended in enumerate(dones):
             if env_ended:
-                episodic_returns[task_names[i]].append(
-                    float(infos["final_info"]["episode"]["r"][i])
-                )
-                if len(episodic_returns[task_names[i]]) <= num_episodes:
-                    successes[task_names[i]] += int(infos["final_info"]["success"][i])
+                episode_return = float(infos["final_info"]["episode"]["r"][i])
+                success = int(infos["final_info"]["success"][i])
 
+                env_episodic_returns[i].append(episode_return)
+
+                if len(env_episodic_returns[i]) <= num_episodes:
+                    env_successes[i] += success
+
+    # Main statistics are over the batch of eval envs only
     episodic_returns = {
-        task_name: returns[:num_episodes]
-        for task_name, returns in episodic_returns.items()
+        i: returns[:num_episodes] for i, returns in env_episodic_returns.items()
     }
+    success_rate_per_env = env_successes / num_episodes
 
-    success_rate_per_task = {
-        task_name: task_successes / num_episodes
-        for task_name, task_successes in successes.items()
+    mean_success_rate = float(np.mean(success_rate_per_env))
+    mean_returns = float(np.mean(list(episodic_returns.values())))
+
+    # Env class / task statistics for logging
+    task_names = _get_task_names(eval_envs)
+    task_names_unique = list(dict.fromkeys(task_names))
+    task_env_indices: dict[str, list[int]] = {
+        task_name: [] for task_name in task_names_unique
     }
-    mean_success_rate = np.mean(list(success_rate_per_task.values()))
-    mean_returns = np.mean(list(episodic_returns.values()))
+    for env_idx, task_name in enumerate(task_names):
+        task_env_indices[task_name].append(env_idx)
+    success_rate_per_task = {}
+    episodic_returns_per_task = {}
+    for task_name in task_names_unique:
+        env_indices = task_env_indices[task_name]
+        success_rate_per_task[task_name] = float(
+            np.sum(success_rate_per_env[env_indices]) / len(env_indices)
+        )
+        episodic_returns_per_task[task_name] = [
+            episode_return
+            for env_idx in env_indices
+            for episode_return in episodic_returns[env_idx]
+        ]
 
     eval_envs.call("toggle_terminate_on_success", terminate_on_success)
 
     return (
-        float(mean_success_rate),
-        float(mean_returns),
+        mean_success_rate,
+        mean_returns,
         success_rate_per_task,
-        episodic_returns,
+        episodic_returns_per_task,
     )
 
 
 def metalearning_evaluation(
     agent: MetaLearningAgent,
-    eval_envs: gym.vector.SyncVectorEnv | gym.vector.AsyncVectorEnv,
+    eval_envs: gym.vector.VectorEnv,
     num_evals: int = 10,  # Assuming 40 goals per test task and meta batch size of 20
     adaptation_steps: int = 1,
     adaptation_episodes: int = 10,
     evaluation_episodes: int = 3,
 ) -> tuple[float, float, dict[str, float]]:
+    assert isinstance(eval_envs, QueryableVectorEnv)
+
     eval_envs.call("toggle_sample_tasks_on_reset", False)
     eval_envs.call("toggle_terminate_on_success", False)
-    task_names = _get_task_names(eval_envs)
+    task_names_unique = list(dict.fromkeys(_get_task_names(eval_envs)))
 
     total_mean_success_rate = 0.0
     total_mean_return = 0.0
-    success_rate_per_task = np.zeros((num_evals, len(set(task_names))))
+    success_rate_per_task = np.zeros((num_evals, len(task_names_unique)))
 
     for i in range(num_evals):
         obs: npt.NDArray[np.float64]
@@ -155,11 +174,15 @@ def metalearning_evaluation(
         )
         total_mean_success_rate += mean_success_rate
         total_mean_return += mean_return
-        success_rate_per_task[i] = np.array(list(_success_rate_per_task.values()))
+        success_rate_per_task[i] = np.array(
+            [_success_rate_per_task[task_name] for task_name in task_names_unique]
+        )
 
-    success_rates = (success_rate_per_task).mean(axis=0)
+    # Env class / task success rates for logs only
+    mean_success_rate_per_task = (success_rate_per_task).mean(axis=0)
     task_success_rates = {
-        task_name: success_rates[i] for i, task_name in enumerate(set(task_names))
+        task_name: mean_success_rate_per_task[i]
+        for i, task_name in enumerate(task_names_unique)
     }
 
     return (

--- a/metaworld/policies/policy.py
+++ b/metaworld/policies/policy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import warnings
 from typing import Any, Callable
 
 import numpy as np
@@ -41,16 +40,12 @@ def move(
         p: constant to scale response
 
     Returns:
-        Response that will decrease abs(to_xyz - from_xyz)
+        Clipped response that will decrease abs(to_xyz - from_xyz)
     """
     error = to_xyz - from_xyz
     response = p * error
-    if np.any(np.absolute(response) > 1.0):
-        warnings.warn(
-            "Constant(s) may be too high. Environments clip response to [-1, 1]"
-        )
 
-    return response
+    return np.clip(response, -1.0, 1.0)
 
 
 class Policy(abc.ABC):

--- a/metaworld/types.py
+++ b/metaworld/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, NamedTuple, Tuple
+from typing import Any, NamedTuple, Protocol, Tuple, runtime_checkable
 
 import numpy as np
 import numpy.typing as npt
@@ -47,3 +47,12 @@ class HammerInitConfigDict(TypedDict):
 class StickInitConfigDict(TypedDict):
     stick_init_pos: npt.NDArray[Any]
     hand_init_pos: npt.NDArray[Any]
+
+
+@runtime_checkable
+class QueryableVectorEnv(Protocol):
+    def get_attr(self, name: str) -> Any: ...
+
+    def set_attr(self, name: str, values: Any) -> Any: ...
+
+    def call(self, name: str, *args, **kwargs) -> Any: ...

--- a/metaworld/wrappers.py
+++ b/metaworld/wrappers.py
@@ -18,14 +18,17 @@ class OneHotWrapper(gym.ObservationWrapper, gym.utils.RecordConstructorArgs):
         assert isinstance(env.observation_space, gym.spaces.Box)
         env_lb = env.observation_space.low
         env_ub = env.observation_space.high
-        one_hot_ub = np.ones(num_tasks)
-        one_hot_lb = np.zeros(num_tasks)
+        obs_dtype = env.observation_space.dtype
+        one_hot_ub = np.ones(num_tasks, dtype=obs_dtype)
+        one_hot_lb = np.zeros(num_tasks, dtype=obs_dtype)
 
-        self.one_hot = np.zeros(num_tasks)
+        self.one_hot = np.zeros(num_tasks, dtype=obs_dtype)
         self.one_hot[task_idx] = 1.0
 
         self._observation_space = gym.spaces.Box(
-            np.concatenate([env_lb, one_hot_lb]), np.concatenate([env_ub, one_hot_ub])
+            np.concatenate([env_lb, one_hot_lb]),
+            np.concatenate([env_ub, one_hot_ub]),
+            dtype=obs_dtype,
         )
 
     def observation(self, obs: NDArray) -> NDArray:

--- a/tests/metaworld/test_evaluation.py
+++ b/tests/metaworld/test_evaluation.py
@@ -16,10 +16,16 @@ from metaworld.types import QueryableVectorEnv
 class ScriptedPolicyAgent(evaluation.MetaLearningAgent):
     def __init__(
         self,
-        envs: gym.vector.VectorEnv,
+        envs: gym.Env | gym.vector.VectorEnv,
         num_rollouts: int | None = None,
         max_episode_steps: int | None = None,
     ):
+        if not isinstance(envs, gym.vector.VectorEnv):
+            env = envs
+            envs = gym.vector.SyncVectorEnv(
+                [lambda: env], autoreset_mode=gym.vector.AutoresetMode.SAME_STEP
+            )
+
         env_task_names = evaluation._get_task_names(envs)
         self.policies = [ENV_POLICY_MAP[task]() for task in env_task_names]
         self.num_rollouts = num_rollouts
@@ -115,34 +121,62 @@ def test_evaluation():
         raise AssertionError(f"Not all tasks got > .8 success rate: {failed_tasks}")
 
 
-# @pytest.mark.parametrize("benchmark", ("reach-v3",))
-# def test_evaluation_mt1(benchmark):
-#     SEED = 1
-#     max_episode_steps = 300
-#     num_episodes = 50
-#     num_envs = 10
+@pytest.mark.parametrize("benchmark", ("reach-v3",))
+def test_evaluation_mt1(benchmark):
+    SEED = 1
+    num_episodes = 5
 
-#     random.seed(SEED)
-#     np.random.seed(SEED)
-#     envs = gym.make_vec(
-#         "Meta-World/MT1",
-#         env_name=benchmark,
-#         seed=SEED,
-#         max_episode_steps=max_episode_steps,
-#         vector_strategy="async",
-#         num_envs=num_envs
-#     )
-#     agent = ScriptedPolicyAgent(envs)
-#     mean_success_rate, mean_returns, success_rate_per_task, _ = evaluation.evaluation(
-#         agent,
-#         envs,
-#         num_episodes=num_episodes,
-#     )
-#     assert isinstance(mean_returns, float)
-#     assert set(success_rate_per_task) == {benchmark}
-#     assert mean_success_rate >= 0.80
-#     assert success_rate_per_task[benchmark] >= 0.80
-#     assert np.isclose(mean_success_rate, success_rate_per_task[benchmark])
+    random.seed(SEED)
+    np.random.seed(SEED)
+    env = gym.make(
+        "Meta-World/MT1",
+        env_name=benchmark,
+        seed=SEED,
+    )
+    agent = ScriptedPolicyAgent(env)
+    mean_success_rate, mean_returns, success_rate_per_task, _ = evaluation.evaluation(
+        agent,
+        env,
+        num_episodes=num_episodes,
+    )
+    assert isinstance(mean_returns, float)
+    assert set(success_rate_per_task) == {benchmark}
+    assert mean_success_rate >= 0.80
+    assert success_rate_per_task[benchmark] >= 0.80
+    assert np.isclose(mean_success_rate, success_rate_per_task[benchmark])
+
+
+@pytest.mark.parametrize("benchmark", ("reach-v3",))
+def test_evaluation_mt1_vectorized(benchmark):
+    SEED = 1
+    max_episode_steps = 300
+    num_envs = 10
+    num_goals = 50
+    num_episodes = num_goals // num_envs
+
+    random.seed(SEED)
+    np.random.seed(SEED)
+    envs = gym.make_vec(
+        "Meta-World/MT1-vectorized",
+        env_name=benchmark,
+        seed=SEED,
+        max_episode_steps=max_episode_steps,
+        vector_strategy="async",
+        num_envs=num_envs,
+        num_goals=num_goals,
+    )
+    assert isinstance(envs, gym.vector.SyncVectorEnv | gym.vector.AsyncVectorEnv)
+    agent = ScriptedPolicyAgent(envs)
+    mean_success_rate, mean_returns, success_rate_per_task, _ = evaluation.evaluation(
+        agent,
+        envs,
+        num_episodes=num_episodes,
+    )
+    assert isinstance(mean_returns, float)
+    assert set(success_rate_per_task) == {benchmark}
+    assert mean_success_rate >= 0.80
+    assert success_rate_per_task[benchmark] >= 0.80
+    assert np.isclose(mean_success_rate, success_rate_per_task[benchmark])
 
 
 # @pytest.mark.skip

--- a/tests/metaworld/test_evaluation.py
+++ b/tests/metaworld/test_evaluation.py
@@ -10,17 +10,18 @@ import pytest
 import metaworld  # noqa: F401
 from metaworld import evaluation
 from metaworld.policies import ENV_POLICY_MAP
+from metaworld.types import QueryableVectorEnv
 
 
 class ScriptedPolicyAgent(evaluation.MetaLearningAgent):
     def __init__(
         self,
-        envs: gym.vector.SyncVectorEnv | gym.vector.AsyncVectorEnv,
+        envs: gym.vector.VectorEnv,
         num_rollouts: int | None = None,
         max_episode_steps: int | None = None,
     ):
         env_task_names = evaluation._get_task_names(envs)
-        self.policies = [ENV_POLICY_MAP[task]() for task in env_task_names]  # type: ignore
+        self.policies = [ENV_POLICY_MAP[task]() for task in env_task_names]
         self.num_rollouts = num_rollouts
         self.max_episode_steps = max_episode_steps
         self.adapt_calls = 0
@@ -28,7 +29,7 @@ class ScriptedPolicyAgent(evaluation.MetaLearningAgent):
         self.resets = 0
 
     def reset(self, env_mask: npt.NDArray[np.bool_]) -> None:
-        self.resets += np.sum(env_mask)  # type: ignore
+        self.resets += np.sum(env_mask)
 
     def init(self) -> None:
         return
@@ -67,7 +68,9 @@ class ScriptedPolicyAgent(evaluation.MetaLearningAgent):
         self.adapt_calls += 1
 
 
-class RemovePartialObservabilityWrapper(gym.vector.VectorWrapper):
+class RemovePartialObservabilityWrapper(QueryableVectorEnv, gym.vector.VectorWrapper):
+    env: QueryableVectorEnv
+
     def get_attr(self, name):
         return self.env.get_attr(name)
 
@@ -83,7 +86,7 @@ class RemovePartialObservabilityWrapper(gym.vector.VectorWrapper):
 
 
 def test_evaluation():
-    SEED = 42
+    SEED = 1
     max_episode_steps = 300  # To speed up the test
     num_episodes = 50
 
@@ -97,12 +100,49 @@ def test_evaluation():
     )
     agent = ScriptedPolicyAgent(envs)
     mean_success_rate, mean_returns, success_rate_per_task, _ = evaluation.evaluation(
-        agent, envs, num_episodes=num_episodes
+        agent,
+        envs,
+        num_episodes=num_episodes,
     )
     assert isinstance(mean_returns, float)
     assert mean_success_rate >= 0.80
     assert len(success_rate_per_task) == envs.num_envs
-    assert np.all(np.array(list(success_rate_per_task.values())) >= 0.80)
+    failed_tasks: list[tuple[str, float]] = []
+    for task_name, success_rate in success_rate_per_task.items():
+        if success_rate < 0.80:
+            failed_tasks.append((task_name, success_rate))
+    if len(failed_tasks) > 0:
+        raise AssertionError(f"Not all tasks got > .8 success rate: {failed_tasks}")
+
+
+# @pytest.mark.parametrize("benchmark", ("reach-v3",))
+# def test_evaluation_mt1(benchmark):
+#     SEED = 1
+#     max_episode_steps = 300
+#     num_episodes = 50
+#     num_envs = 10
+
+#     random.seed(SEED)
+#     np.random.seed(SEED)
+#     envs = gym.make_vec(
+#         "Meta-World/MT1",
+#         env_name=benchmark,
+#         seed=SEED,
+#         max_episode_steps=max_episode_steps,
+#         vector_strategy="async",
+#         num_envs=num_envs
+#     )
+#     agent = ScriptedPolicyAgent(envs)
+#     mean_success_rate, mean_returns, success_rate_per_task, _ = evaluation.evaluation(
+#         agent,
+#         envs,
+#         num_episodes=num_episodes,
+#     )
+#     assert isinstance(mean_returns, float)
+#     assert set(success_rate_per_task) == {benchmark}
+#     assert mean_success_rate >= 0.80
+#     assert success_rate_per_task[benchmark] >= 0.80
+#     assert np.isclose(mean_success_rate, success_rate_per_task[benchmark])
 
 
 # @pytest.mark.skip
@@ -111,12 +151,12 @@ def test_metalearning_evaluation(benchmark):
     SEED = 42
 
     max_episode_steps = 300
-    meta_batch_size = 10  # Number of parallel envs
-
     adaptation_steps = 2  # Number of adaptation iterations
     adaptation_episodes = 2  # Number of train episodes per task in meta_batch_size per adaptation iteration
-    num_evals = 50  # Number of different task vectors tested for each task
-    num_episodes = 1  # Number of test episodes per task vector
+    num_episodes = 3  # Number of test episodes per task vector
+
+    meta_batch_size = 10  # Number of parallel envs
+    goals_per_task = 50  # goal positions for each distinct env class  / task
 
     random.seed(SEED)
     np.random.seed(SEED)
@@ -126,9 +166,14 @@ def test_metalearning_evaluation(benchmark):
         vector_strategy="async",
         meta_batch_size=meta_batch_size,
         max_episode_steps=max_episode_steps,
+        total_tasks_per_cls=goals_per_task,
     )
     envs = RemovePartialObservabilityWrapper(envs)
     agent = ScriptedPolicyAgent(envs, adaptation_episodes, max_episode_steps)
+
+    num_classes = 5  # task size of ML10/45 test set
+    num_evals = num_classes * goals_per_task // meta_batch_size
+
     (
         mean_success_rate,
         mean_returns,
@@ -150,3 +195,49 @@ def test_metalearning_evaluation(benchmark):
         agent.step_calls
         == num_evals * adaptation_steps * adaptation_episodes * max_episode_steps
     )
+
+
+@pytest.mark.parametrize("benchmark", ("reach-v3",))
+def test_metalearning_evaluation_ml1(benchmark):
+    SEED = 42
+
+    max_episode_steps = 300
+    adaptation_steps = 2  # Number of adaptation iterations
+    adaptation_episodes = 2  # Number of train episodes per task in meta_batch_size per adaptation iteration
+    num_episodes = 3  # Number of test episodes per task vector
+
+    meta_batch_size = 10  # Number of parallel envs
+    goals_per_task = 50  # goal positions for each distinct env class  / task
+
+    random.seed(SEED)
+    np.random.seed(SEED)
+    envs = gym.make_vec(
+        "Meta-World/ML1-test",
+        env_name=benchmark,
+        seed=SEED,
+        vector_strategy="async",
+        meta_batch_size=meta_batch_size,
+        max_episode_steps=max_episode_steps,
+        total_tasks_per_cls=goals_per_task,
+    )
+    envs = RemovePartialObservabilityWrapper(envs)
+    agent = ScriptedPolicyAgent(envs, adaptation_episodes, max_episode_steps)
+
+    num_classes = 1  # task size of ML1 test set
+    num_evals = num_classes * goals_per_task // meta_batch_size
+
+    (
+        mean_success_rate,
+        mean_returns,
+        success_rate_per_task,
+    ) = evaluation.metalearning_evaluation(
+        agent,
+        envs,
+        evaluation_episodes=num_episodes,
+        adaptation_episodes=adaptation_episodes,
+        adaptation_steps=adaptation_steps,
+        num_evals=num_evals,
+    )
+    assert isinstance(mean_returns, float)
+    assert set(success_rate_per_task) == {benchmark}
+    assert np.isclose(mean_success_rate, success_rate_per_task[benchmark])

--- a/tests/metaworld/test_gym_make.py
+++ b/tests/metaworld/test_gym_make.py
@@ -105,6 +105,51 @@ def test_mt1(env_name: str):
     assert not env.unwrapped._partially_observable
 
 
+@pytest.mark.parametrize("vector_strategy", ("sync", "async"))
+def test_mt1_vectorized(vector_strategy: str):
+    env_name = "reach-v3"
+    num_envs = 4
+    num_goals = 20
+    max_episode_steps = 10
+
+    envs = gym.make_vec(
+        "Meta-World/MT1-vectorized",
+        env_name=env_name,
+        vector_strategy=vector_strategy,
+        seed=42,
+        num_envs=num_envs,
+        num_goals=num_goals,
+        max_episode_steps=max_episode_steps,
+    )
+
+    expected_vectorisation = getattr(
+        gym.vector, f"{vector_strategy.capitalize()}VectorEnv"
+    )
+    assert isinstance(envs, expected_vectorisation)
+    assert envs.num_envs == num_envs
+    assert set(_get_task_names(envs)) == {env_name}
+
+    envs_tasks = envs.get_attr("tasks")
+    assert sum(len(env_tasks) for env_tasks in envs_tasks) == num_goals
+    assert all(len(env_tasks) == num_goals // num_envs for env_tasks in envs_tasks)
+    task_data = {task.data for env_tasks in envs_tasks for task in env_tasks}
+    assert len(task_data) == num_goals
+
+    envs.reset()
+    partially_observable = all(envs.get_attr("_partially_observable"))
+    assert not partially_observable
+
+
+def test_mt1_vectorized_requires_even_goal_split():
+    with pytest.raises(ValueError, match="num_envs must evenly divide num_goals"):
+        gym.make_vec(
+            "Meta-World/MT1-vectorized",
+            env_name="reach-v3",
+            num_envs=6,
+            num_goals=20,
+        )
+
+
 @pytest.mark.parametrize("env_name", ALL_V3_ENVIRONMENTS_GOAL_HIDDEN.keys())
 def test_goal_hidden(env_name: str):
     env = gym.make("Meta-World/goal_hidden", env_name=env_name, seed=None)


### PR DESCRIPTION
A user of [my metaworld-algorithms repository](https://github.com/rainx0r/metaworld-algorithms) recently reported a bug with the metalearning evaluation procedure, primarily seeming to affect ML1 but likely also affects ML10 and ML45. This was discussed in [this issue](https://github.com/rainx0r/metaworld-algorithms/issues/10)

This PR addresses this issue by decoupling how we track successes per task sampled in the meta batch from the task_name.

### Draft status
What remains to be done is run some meta-learning experiments for ML10 and ML45 under this fix and compare