### PR TITLE
Add explicit contact params to peg geom to fix peg-insert-side under mujoco>=3.4

### DIFF
--- a/metaworld/assets/sawyer_xyz/sawyer_peg_insertion_side.xml
+++ b/metaworld/assets/sawyer_xyz/sawyer_peg_insertion_side.xml
@@ -9,7 +9,7 @@
 
         <body name="peg" pos="0 0.6 0.03">
           <inertial pos="0 0 0" mass="0.1" diaginertia="100000 100000 100000"/>
-          <geom name="peg" euler="0 1.57 0" size="0.015 0.015 0.12" type="box" mass=".1" rgba="0.3 1 0.3 1" conaffinity="1" contype="1" group="1" condim="4" margin="0.001" solimp="0.95 0.99 0.01" solref="0.01 1" friction="2 0.1 0.002"/>
+          <geom name="peg" euler="0 1.57 0" size="0.015 0.015 0.12" type="box" mass=".1" rgba="0.3 1 0.3 1" conaffinity="1" contype="1" group="1" solref="0.025 1"/>
           <joint type="free" limited="false" damping="0.005"/>
           <site name="pegHead" pos="-0.1 0 0" size="0.005" rgba="0.8 0 0 1"/>
           <site name="pegEnd" pos="0.1 0 0" size="0.005" rgba="0.8 0 0 1"/>

--- a/metaworld/assets/sawyer_xyz/sawyer_peg_insertion_side.xml
+++ b/metaworld/assets/sawyer_xyz/sawyer_peg_insertion_side.xml
@@ -9,7 +9,7 @@
 
         <body name="peg" pos="0 0.6 0.03">
           <inertial pos="0 0 0" mass="0.1" diaginertia="100000 100000 100000"/>
-          <geom name="peg" euler="0 1.57 0" size="0.015 0.015 0.12" type="box" mass=".1" rgba="0.3 1 0.3 1" conaffinity="1" contype="1" group="1"/>
+          <geom name="peg" euler="0 1.57 0" size="0.015 0.015 0.12" type="box" mass=".1" rgba="0.3 1 0.3 1" conaffinity="1" contype="1" group="1" condim="4" margin="0.001" solimp="0.95 0.99 0.01" solref="0.01 1" friction="2 0.1 0.002"/>
           <joint type="free" limited="false" damping="0.005"/>
           <site name="pegHead" pos="-0.1 0 0" size="0.005" rgba="0.8 0 0 1"/>
           <site name="pegEnd" pos="0.1 0 0" size="0.005" rgba="0.8 0 0 1"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "gymnasium>=1.1",
-    "mujoco==3.3.0",
+    "mujoco==3.8.1",
     "numpy>=1.18",
     "scipy>=1.4.1",
     "imageio"


### PR DESCRIPTION
MuJoCo 3.4 [fixed a box-box collision behaviour bug](https://mujoco.readthedocs.io/en/3.4.0/changelog.html#bug-fixes), which in turn broke peg-insert-side. Copying over the contact params from the gripper pads in [xyz_base.xml](https://github.com/Farama-Foundation/Metaworld/blob/master/metaworld/assets/objects/assets/xyz_base.xml#L171) and making them explicit on the peg rather than using the defaults seems to fix it.

This does change the environment dynamics, but also so does the MuJoCo 3.4 box-box collision bug fix.

### Draft status
What remains to be done is:
- Collect data on MuJoCo 3.3 to see how these explicit collision parameters on the peg affect trajectories quantitatively and qualitatively
- Run MT1 runs on `peg-insert-side-v3` before/after the collision parameter change, on MuJoCo 3.3, to see how it affects policy learning
- Run MT1 runs on `peg-insert-side-v3` on MuJoCo 3.8.1 using this patch and compare qualitatively and quantitatively the policy and learning dynamics to the unchanged MuJoCo 3.3 environment