### PR TITLE
Add local docs-serve tooling and fix broken banner logo

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,22 @@
+set shell := ["bash", "-cu"]
+
+venv := ".venv"
+python := venv + "/bin/python"
+
+default:
+    @just --list
+
+docs-install:
+    python3 -m venv {{venv}}
+    {{python}} -m pip install --upgrade pip
+    {{python}} -m pip install -e .
+    {{python}} -m pip install -r docs/requirements.txt
+
+docs-serve: docs-install
+    {{venv}}/bin/sphinx-autobuild -b dirhtml docs docs/_build/html --open-browser
+
+docs-build: docs-install
+    {{venv}}/bin/sphinx-build -b dirhtml docs docs/_build/html
+
+docs-clean:
+    rm -rf docs/_build

--- a/docs/_static/img/metaworld-text.svg
+++ b/docs/_static/img/metaworld-text.svg
@@ -71,11 +71,6 @@
    inkscape:groupmode="layer">
   <metadata
    id="CorelCorpID_0Corel-Layer" />
-<<<<<<< HEAD
-
-=======
-
->>>>>>> 5186a934e5af1905b684bda17e41836d9cf73287
  <rect
    style="fill:#ffffff;stroke-width:15;stroke-linecap:round"
    id="rect572"

--- a/docs/_static/metaworld-text.svg
+++ b/docs/_static/metaworld-text.svg
@@ -71,11 +71,6 @@
    inkscape:groupmode="layer">
   <metadata
    id="CorelCorpID_0Corel-Layer" />
-<<<<<<< HEAD
-
-=======
-
->>>>>>> 5186a934e5af1905b684bda17e41836d9cf73287
  <rect
    style="fill:#ffffff;stroke-width:15;stroke-linecap:round"
    id="rect572"

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ firstpage:
 lastpage:
 ---
 
-```{project-logo} ../metaworld-text-banner.svg
+```{project-logo} _static/metaworld-text.svg
 :alt: Metaworld Logo
 ```
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+just = "latest"


### PR DESCRIPTION
## Summary

- **`mise.toml` + `Justfile`**: add `mise` config declaring the `just` toolchain and a `Justfile` exposing `docs-install`, `docs-serve`, `docs-build`, and `docs-clean`. `docs-serve` builds the Sphinx site in an isolated `.venv` with `sphinx-autobuild` live reload, so contributors can preview the docs site locally with a single `just docs-serve`. The install + `dirhtml` builder mirror `.github/workflows/build-docs.yml`.
- **`docs/index.md`**: point the `{project-logo}` directive at the in-repo `_static/metaworld-text.svg` instead of the root-level `metaworld-text-banner.svg`, which was deleted and produced a 404 for the banner.
- **`docs/_static/metaworld-text.svg` and `docs/_static/img/metaworld-text.svg`**: strip leftover Git merge conflict markers (`<<<<<<<`/`=======`/`>>>>>>>`) that had been committed into both files, making them invalid XML so the banner failed to render. Both conflict sides were empty, so no image content changed.