### PR TITLE
Enable docs versioning on metaworld.farama.org

### DIFF
--- a/.github/workflows/docs-build-release.yml
+++ b/.github/workflows/docs-build-release.yml
@@ -1,14 +1,16 @@
-name: Build and Deploy Docs
+name: Build release documentation website
+
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v?*.*.*'
 
 permissions:
   contents: write
 
 jobs:
   docs:
-    name: Generate Website
+    name: Generate Website for new version
     runs-on: ubuntu-latest
 
     steps:
@@ -35,9 +37,18 @@ jobs:
       - name: Remove .doctrees
         run: rm -r _build/.doctrees
 
-      - name: Upload to GitHub Pages
+      - name: Upload to GitHub Pages (versioned)
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: _build
-          target-folder: main
+          target-folder: ${{ github.ref_name }}
           clean: false
+
+      - name: Upload to GitHub Pages (latest at root)
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ !contains(github.ref_name, 'a') }}
+        with:
+          folder: _build
+          clean-exclude: |
+            *.*.*/
+            main


### PR DESCRIPTION
## Problem

The docs site (https://metaworld.farama.org/) is built with the Farama version-selector theme — its pages carry the `versioningConfig` script that fetches `/main/_static/versioning/versioning_menu.html` — but the current `build-docs.yml` deploys the build to the **root** of `gh-pages` (`folder: _build`, no `target-folder`). So there is no `/main/` directory, the menu fetch 404s, and the version dropdown never loads. There is also no workflow that deploys tagged releases, so there are no `/<version>/` folders to choose from.

This matches the live behaviour: `/main/_static/versioning/versioning_menu.html` returns 404 on metaworld, while it returns 200 on gymnasium/pettingzoo/minari/etc.

## Change

Mirror the Gymnasium setup (`docs-build-dev.yml` + `docs-build-release.yml`):

- **`build-docs.yml`** (push to `main`): deploy under `target-folder: main` with `clean: false`, so main docs live at `/main/` and don't wipe sibling version folders.
- **`docs-build-release.yml`** (new, on `v?*.*.*` tags): reuses this repo's existing build steps, then deploys the build to `/<tag>/` (`clean: false`) and — for non-alpha tags — copies the latest release to the site root (`clean-exclude` preserves `*.*.*/` and `main`). The `v?*.*.*` trigger matches both `v`-prefixed and un-prefixed tags (this repo has both).

The version dropdown lists folders from the `gh-pages` tree via the GitHub API, so once `/main/` exists the selector loads; future releases add `/<tag>/` entries.

## Notes / follow-ups for maintainers

- **No historical back-fill.** Old tags are not retroactively built (old code against today's docs deps is fragile). Versions accumulate forward from the next release, exactly as Gymnasium did (its dropdown only goes back to `v0.26.3`). Until the next release, the dropdown shows just `main`.
- After this merges, the **next release** populates the site root with that release's docs. Until then, the bare `metaworld.farama.org/` root keeps serving the previous flat build (stale but functional); merging this and cutting a release resolves it. If a sooner root refresh is wanted, re-running the release workflow for the latest tag (`3.0.0`) would do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)