### PR TITLE
Replace removed `np.float_` alias with `np.float64` for NumPy 2.0 compatibility

### DIFF
--- a/metaworld/utils/reward_utils.py
+++ b/metaworld/utils/reward_utils.py
@@ -184,9 +184,9 @@ def inverse_tolerance(
 
 
 def rect_prism_tolerance(
-    curr: npt.NDArray[np.float_],
-    zero: npt.NDArray[np.float_],
-    one: npt.NDArray[np.float_],
+    curr: npt.NDArray[np.float64],
+    zero: npt.NDArray[np.float64],
+    one: npt.NDArray[np.float64],
 ) -> float:
     """Computes a reward if curr is inside a rectangular prism region.
 

--- a/tests/metaworld/test_reward_utils.py
+++ b/tests/metaworld/test_reward_utils.py
@@ -1,0 +1,25 @@
+import typing
+
+import numpy as np
+
+from metaworld.utils import reward_utils
+
+
+def test_rect_prism_tolerance_type_hints_resolvable():
+    # np.float_ was removed in NumPy 2.0; resolving the annotations
+    # must not raise AttributeError under numpy>=2.
+    hints = typing.get_type_hints(reward_utils.rect_prism_tolerance)
+    assert set(hints) >= {"curr", "zero", "one"}
+
+
+def test_rect_prism_tolerance_values():
+    zero = np.array([0.0, 0.0, 0.0])
+    one = np.array([1.0, 1.0, 1.0])
+    # corner with reward 1
+    assert reward_utils.rect_prism_tolerance(one, zero, one) == 1.0
+    # opposite corner -> 0
+    assert reward_utils.rect_prism_tolerance(zero, zero, one) == 0.0
+    # outside the prism -> 1.0 (no-collision-penalty semantics)
+    assert (
+        reward_utils.rect_prism_tolerance(np.array([2.0, 2.0, 2.0]), zero, one) == 1.0
+    )


### PR DESCRIPTION
## What

`rect_prism_tolerance` in `metaworld/utils/reward_utils.py` annotated its three parameters as `npt.NDArray[np.float_]`. This replaces those three annotations with `npt.NDArray[np.float64]` and adds a small test file `tests/metaworld/test_reward_utils.py`.

## Why

`np.float_` was removed in NumPy 2.0 — it was only ever an alias for `np.float64`. Metaworld declares `requires-python = ">=3.10,<3.14"` and lists Python 3.13 in its classifiers/CI matrix, and Python 3.13 cannot use NumPy 1.x, so the NumPy 2 code path is a supported, exercised configuration.

Because `reward_utils.py` uses `from __future__ import annotations`, the annotations are stored as strings and this does not crash at import time. However, any consumer that resolves the annotations under NumPy >= 2 hits:

```
AttributeError: module 'numpy' has no attribute 'float_'
```

This includes `typing.get_type_hints(rect_prism_tolerance)` and `mypy` runs against the package (Metaworld ships a `py.typed` marker, so its annotations are part of the public typed API). The pre-commit mypy hook is pinned to `numpy==1.26.1`, where `np.float_` still exists, which is why this went unnoticed.

`np.float64` is valid and identical in meaning on both NumPy 1.x and 2.x, so the change is fully backward compatible and still passes the numpy==1.26.1-pinned pre-commit mypy.

`rect_prism_tolerance` is live code: it is called twice in `metaworld/envs/sawyer_peg_insertion_side_v3.py` for the collision-box reward term.

## Testing

Added `tests/metaworld/test_reward_utils.py` with two tests:
- `test_rect_prism_tolerance_type_hints_resolvable` — resolves the function's type hints via `typing.get_type_hints`. This fails before the fix (`AttributeError: np.float_ was removed in the NumPy 2.0 release`) and passes after, under numpy >= 2.
- `test_rect_prism_tolerance_values` — documents the reward values at the two prism corners and outside the prism.

Run:

```
python -m pytest tests/metaworld/test_reward_utils.py -q
```

Verified with numpy 2.5.1 on Python 3.13: `2 passed`. `black`/`isort` clean on the changed files.
