### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,6 +6,9 @@
 # derived from https://github.com/Farama-Foundation/PettingZoo/blob/e230f4d80a5df3baf9bd905149f6d4e8ce22be31/.github/workflows/build-publish.yml
 name: Build artifact for PyPI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -35,6 +38,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
     - build-wheels
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Metaworld/security/code-scanning/2](https://github.com/Farama-Foundation/Metaworld/security/code-scanning/2)

Add explicit `permissions` in `.github/workflows/pypi-publish.yml`:

- At workflow root: set minimal default permissions for all jobs:
  - `contents: read`
- For the `publish` job: override with `permissions: {}` to disable `GITHUB_TOKEN` access entirely, since publishing uses `PYPI_API_TOKEN` and does not require repository token scopes.

This preserves behavior while enforcing least privilege and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
