### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,6 +14,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ubuntu-latest
@@ -34,6 +37,8 @@ jobs:
         path: dist
 
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs:
     - build-wheels


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Metaworld/security/code-scanning/1](https://github.com/Farama-Foundation/Metaworld/security/code-scanning/1)

Add explicit `permissions` blocks with least privilege:

- At workflow root: `permissions: { contents: read }` as a secure default for all jobs.
- For the `publish` job: override with `permissions: { contents: read }` explicitly as well (keeps intent clear and avoids accidental privilege creep).

In this specific file, edit `.github/workflows/pypi-publish.yml`:
1. Insert a root-level `permissions` block after the `on:` triggers.
2. Add a job-level `permissions` block under `publish:` (before `runs-on`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
