### PR TITLE
fix(ci): remove duplicated permission declaration

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,9 +6,6 @@
 # derived from https://github.com/Farama-Foundation/PettingZoo/blob/e230f4d80a5df3baf9bd905149f6d4e8ce22be31/.github/workflows/build-publish.yml
 name: Build artifact for PyPI
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [main]


### PR DESCRIPTION
CodeQL double-applied the same permission patch, which broke CI on main.