### PR TITLE
Carry the observation dtype into the wrapped space

### DIFF
--- a/metaworld/wrappers.py
+++ b/metaworld/wrappers.py
@@ -24,8 +24,14 @@ class OneHotWrapper(gym.ObservationWrapper, gym.utils.RecordConstructorArgs):
         self.one_hot = np.zeros(num_tasks)
         self.one_hot[task_idx] = 1.0
 
+        # `Box` falls back to float32 when no dtype is given, while the Sawyer
+        # observation space is float64 and `observation()` concatenates float64
+        # arrays. Without carrying the dtype across, the wrapper declared a space
+        # its own observations never lay in.
         self._observation_space = gym.spaces.Box(
-            np.concatenate([env_lb, one_hot_lb]), np.concatenate([env_ub, one_hot_ub])
+            np.concatenate([env_lb, one_hot_lb]),
+            np.concatenate([env_ub, one_hot_ub]),
+            dtype=env.observation_space.dtype,
         )
 
     def observation(self, obs: NDArray) -> NDArray:
@@ -57,8 +63,13 @@ class RNNBasedMetaRLWrapper(gym.Wrapper):
         assert isinstance(self.env.action_space, gym.spaces.Box)
         obs_flat_dim = int(np.prod(self.env.observation_space.shape))
         action_flat_dim = int(np.prod(self.env.action_space.shape))
+        # Same as in `OneHotWrapper`: the observation stays float64, so the
+        # declared space has to say so rather than take `Box`'s float32 default.
         self._observation_space = gym.spaces.Box(
-            low=-np.inf, high=np.inf, shape=(obs_flat_dim + action_flat_dim + 1 + 1,)
+            low=-np.inf,
+            high=np.inf,
+            shape=(obs_flat_dim + action_flat_dim + 1 + 1,),
+            dtype=self.env.observation_space.dtype,
         )
         self._normalize_reward = normalize_reward
 

--- a/tests/metaworld/test_wrappers.py
+++ b/tests/metaworld/test_wrappers.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import gymnasium as gym
+import numpy as np
+import pytest
+
+import metaworld  # noqa: F401
+from metaworld.wrappers import OneHotWrapper, RNNBasedMetaRLWrapper
+
+
+def _make_env() -> gym.Env:
+    return gym.make("Meta-World/MT1", env_name="reach-v3", seed=0)
+
+
+@pytest.mark.parametrize(
+    "wrap",
+    [
+        lambda env: OneHotWrapper(env, task_idx=0, num_tasks=10),
+        lambda env: RNNBasedMetaRLWrapper(env),
+    ],
+    ids=["OneHotWrapper", "RNNBasedMetaRLWrapper"],
+)
+def test_wrapper_observation_space_keeps_dtype(wrap):
+    """A wrapper must declare the dtype of the observations it hands back.
+
+    Both wrappers built their `Box` without a dtype, which falls back to
+    float32, while the Sawyer observation space is float64 and both wrappers
+    concatenate float64 arrays. The declared space could not hold its own
+    observations.
+    """
+    env = _make_env()
+    wrapped = wrap(env)
+
+    assert wrapped.observation_space.dtype == env.observation_space.dtype
+
+    obs, _ = wrapped.reset(seed=0)
+    assert np.can_cast(obs.dtype, wrapped.observation_space.dtype)
+
+    obs, _, _, _, _ = wrapped.step(wrapped.action_space.sample())
+    assert np.can_cast(obs.dtype, wrapped.observation_space.dtype)
+
+    env.close()
+
+
+def test_one_hot_wrapper_keeps_the_wrapped_bounds():
+    """The bounds of the wrapped space must survive unrounded.
+
+    Casting them to float32 moved every finite bound the environment declared.
+    """
+    env = _make_env()
+    wrapped = OneHotWrapper(env, task_idx=0, num_tasks=10)
+
+    env_dim = env.observation_space.shape[0]
+    assert np.array_equal(
+        wrapped.observation_space.low[:env_dim], env.observation_space.low
+    )
+    assert np.array_equal(
+        wrapped.observation_space.high[:env_dim], env.observation_space.high
+    )
+
+    env.close()
+
+
+def test_rnn_wrapper_observation_is_inside_its_space():
+    """The recurrent observation is unbounded, so it must lie in its own space."""
+    env = _make_env()
+    wrapped = RNNBasedMetaRLWrapper(env)
+
+    obs, _ = wrapped.reset(seed=0)
+    assert wrapped.observation_space.contains(obs)
+
+    obs, _, _, _, _ = wrapped.step(wrapped.action_space.sample())
+    assert wrapped.observation_space.contains(obs)
+
+    env.close()


### PR DESCRIPTION
## Description

`OneHotWrapper` and `RNNBasedMetaRLWrapper` build their `Box` without a dtype:

```python
self._observation_space = gym.spaces.Box(
    np.concatenate([env_lb, one_hot_lb]), np.concatenate([env_ub, one_hot_ub])
)
```

`Box` falls back to float32 there. The Sawyer observation space is float64 and
both wrappers hand back `np.concatenate` of float64 arrays, so each declared a
space that cannot hold its own observations:

```python
env = gym.make("Meta-World/MT1", env_name="reach-v3", seed=0)
w = OneHotWrapper(env, task_idx=0, num_tasks=10)

env.observation_space.dtype   # float64
w.observation_space.dtype     # float32
w.reset(seed=0)[0].dtype      # float64
```

`np.can_cast(np.float64, np.float32)` is False, so `contains` fails on the
dtype alone. Gymnasium's passive checker already says as much on every
construction:

```
UserWarning: WARN: Box low's precision lowered by casting to float32, current low.dtype=float64
UserWarning: WARN: The obs returned by the `reset()` method is not within the observation space.
```

The bounds suffer too: casting the environment's float64 `low` and `high` to
float32 moves every finite bound `OneHotWrapper` copies across.

Both wrappers are applied by the benchmark constructors themselves —
`use_one_hot=True` is the usual setting for MT10/MT25/MT50 — so this is the
shipped multi-task configuration rather than a corner case.

## What this does not fix

`OneHotWrapper.observation_space.contains(obs)` is still False after this
change, for a reason that has nothing to do with the wrapper: the Sawyer space
itself does not contain its own observations. On `reach-v3` the goal slots 36
to 38 are declared `[0, 0]` while the observation carries the actual goal:

```python
env.observation_space.contains(env.reset(seed=0)[0])   # False, without any wrapper
```

That is the "Box observation space maximum and minimum values are equal"
warning, and it needs a separate look at `sawyer_observation_space`. I have
left it alone here. `RNNBasedMetaRLWrapper` is unbounded, so its `contains`
does go from False to True.

## Tests

New `tests/metaworld/test_wrappers.py`: the declared dtype matches the wrapped
environment for both wrappers, observations from `reset` and `step` cast into
it, the bounds `OneHotWrapper` copies stay unrounded, and the recurrent
observation lies inside its own space. All four fail on `main` and pass here.

`tests/metaworld/test_gym_make.py` is unaffected: the MT10 benchmark cases and
a `test_mt1` slice pass. `pre-commit run` is clean on both files, mypy
included.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
