### PR TITLE
Rebind observation_space when the task changes observability

### DIFF
--- a/metaworld/sawyer_xyz_env.py
+++ b/metaworld/sawyer_xyz_env.py
@@ -309,11 +309,17 @@ class SawyerXYZEnv(SawyerMocapBase, EzPickle):
         self._last_rand_vec = data["rand_vec"]
         del data["rand_vec"]
         new_observability = data["partially_observable"]
-        if new_observability != self._partially_observable:
+        observability_changed = new_observability != self._partially_observable
+        self._partially_observable = new_observability
+        if observability_changed:
             # Force recomputation of the observation space
             # See https://docs.python.org/3/library/functools.html#functools.cached_property
             del self.sawyer_observation_space
-        self._partially_observable = new_observability
+            # `observation_space` was bound to the old Box when the environment
+            # was constructed, so dropping the cached property is not enough on
+            # its own: without rebinding, the environment keeps advertising the
+            # hidden-goal bounds after it has become fully observable.
+            self.observation_space = self.sawyer_observation_space
         del data["partially_observable"]
         self._set_task_inner(**data)
 

--- a/tests/metaworld/test_gym_make.py
+++ b/tests/metaworld/test_gym_make.py
@@ -202,3 +202,33 @@ def test_ml_benchmarks(
 
     partially_observable = all(envs.get_attr("_partially_observable"))
     assert partially_observable
+
+
+@pytest.mark.parametrize("env_name", ["reach-v3", "push-v3", "window-open-v3"])
+def test_observation_space_follows_observability(env_name: str):
+    """A fully observable environment must advertise the goal bounds it uses.
+
+    `set_task` drops the cached `sawyer_observation_space` when observability
+    changes, but `observation_space` was bound to the old Box when the
+    environment was constructed. It kept the hidden-goal bounds of [0, 0], so
+    the goal slots of every observation fell outside the declared space.
+    """
+    env = gym.make("Meta-World/MT1", env_name=env_name, seed=0)
+    inner = env.unwrapped
+    assert isinstance(inner, SawyerXYZEnv)
+
+    # The task is set on the first reset, and with it the observability.
+    obs, _ = env.reset(seed=0)
+    assert not inner._partially_observable
+
+    space = inner.observation_space
+    recomputed = inner.sawyer_observation_space
+    assert np.array_equal(space.low, recomputed.low)
+    assert np.array_equal(space.high, recomputed.high)
+
+    assert space.contains(obs)
+
+    obs, _, _, _, _ = env.step(env.action_space.sample())
+    assert space.contains(obs)
+
+    env.close()


### PR DESCRIPTION
## Description

A Meta-World environment advertises the hidden-goal observation bounds even
after it has become fully observable, so no observation it produces lies inside
its own `observation_space`:

```python
env = gym.make("Meta-World/MT1", env_name="reach-v3", seed=0)
obs, _ = env.reset(seed=0)
inner = env.unwrapped

inner._partially_observable                 # False
inner.observation_space.low[36:39]          # [0. 0. 0.]   <- hidden-goal bounds
inner.sawyer_observation_space.low[36:39]   # [-0.1  0.8  0.05]
obs[36:39]                                  # the actual goal
inner.observation_space.contains(obs)       # False
```

`sawyer_observation_space` is a `cached_property`, and `set_task` already
invalidates it when observability changes:

```python
if new_observability != self._partially_observable:
    # Force recomputation of the observation space
    del self.sawyer_observation_space
self._partially_observable = new_observability
```

The invalidation works — reading the property afterwards gives the right
bounds. What it misses is that `observation_space` is a separate attribute,
bound to the old `Box` back in `__init__`:

```python
mjenv_gym.__init__(self, model_name, ..., observation_space=self.sawyer_observation_space, ...)
```

Dropping the cache never touches it, so the environment keeps handing out the
space it was built with. `set_task` now rebinds it. The flag is also assigned
before the recomputation rather than after, so the property sees the new
observability.

This is the ordinary path: `_partially_observable` starts True, and the first
`reset()` sets the task and flips it, so every fully observable environment is
affected from its first step.

## Tests

`tests/metaworld/test_gym_make.py` gains
`test_observation_space_follows_observability`, over `reach-v3`, `push-v3` and
`window-open-v3`: after the first reset the declared space matches the
recomputed one, and the observations from `reset` and `step` lie inside it. All
three fail on `main` and pass here. The rest of the file is unaffected: the
full `tests/metaworld/test_gym_make.py` run is 365 passed.

This sits next to #594, which fixes a dtype drop in the two observation
wrappers. They touch different files and are independent; #594 notes this bug
as out of its scope.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
